### PR TITLE
feat: add default namespace const; update readme with proper example and breaking change notes

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,3 +2,4 @@
 
 README.md
 sample-app/src/main/java/sample/App.java
+src/main/java/com/flipt/api/core/Defaults.java

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ generated/
 
 bin
 build
+.envrc
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 API documentation is available at <https://www.flipt.io/docs/reference/overview>.
 
+## Breaking Changes
+
+### 0.2.2
+
+Version [0.2.2](https://github.com/flipt-io/flipt-java/releases/tag/0.2.2) of this client introduced a breaking change as it requires the passing of `namespace` parameter to all methods that require it. This is to support the new namespace functionality added to [Flipt v1.20.0](https://www.flipt.io/docs/reference/overview#v1-20-0).
+
+If you are running an older version of Flipt server (< v1.20.0), you should use a pre 0.2.2 version of this client.
+
 ## Install
 
 ### Gradle
@@ -36,16 +44,19 @@ Check out the [sample app](sample-app/src/main/java/sample/App.java) which consu
 
 ```java
 import com.flipt.api.FliptApiClient;
+import com.flipt.api.core.Defaults;
 import com.flipt.api.resources.flags.types.Flag;
 
 public class App {
+  private static final String FLIPT_URL = "http://localhost:8080";
+
   public static void main(String[] args) {
     String token = System.getenv("FLIPT_API_TOKEN");
 
-    FliptApiClient fliptApiClient = FliptApiClient.builder().token(token).url("http://localhost:8080").build();
+    FliptApiClient fliptApiClient = FliptApiClient.builder().token(token).url(FLIPT_URL).build();
 
     try {
-      Flag flag = fliptApiClient.flags().get("flag_abc123");
+      Flag flag = fliptApiClient.flags().get(Defaults.NAMESPACE, "flag_abc123");
       System.out.println("Successfully fetched flag with id" + flag.getKey());
     } catch (Exception e) {
       System.out.println("Encountered error while getting flag" + e.getMessage());

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -1,10 +1,10 @@
 package sample;
 
 import com.flipt.api.FliptApiClient;
+import com.flipt.api.core.Defaults;
 import com.flipt.api.resources.flags.types.Flag;
 
 public class App {
-  private static final String DEFAULT_NAMESPACE = "default";
   private static final String FLIPT_URL = "http://localhost:8080";
 
   public static void main(String[] args) {
@@ -13,7 +13,7 @@ public class App {
     FliptApiClient fliptApiClient = FliptApiClient.builder().token(token).url(FLIPT_URL).build();
 
     try {
-      Flag flag = fliptApiClient.flags().get(DEFAULT_NAMESPACE, "flag_abc123");
+      Flag flag = fliptApiClient.flags().get(Defaults.NAMESPACE, "flag_abc123");
       System.out.println("Successfully fetched flag with id" + flag.getKey());
     } catch (Exception e) {
       System.out.println("Encountered error while getting flag" + e.getMessage());

--- a/src/main/java/com/flipt/api/core/Defaults.java
+++ b/src/main/java/com/flipt/api/core/Defaults.java
@@ -1,0 +1,5 @@
+package com.flipt.api.core;
+
+public final class Defaults {
+    public static final String NAMESPACE = "default";
+}


### PR DESCRIPTION
Fixes: FLI-315

- Adds `Defaults.NAMESPACE` constant to make using the client easier for those without additional namespaces
- Updates example in README
- Adds note on breaking change

cc @dsinghvi to see if there is a potentially better way of handling the namespace key requirement we added to all methods of this API by providing a 'default'